### PR TITLE
cleaning up timings so run time stored as time in sections with no text

### DIFF
--- a/01_predictclearing_mlr3.R
+++ b/01_predictclearing_mlr3.R
@@ -25,8 +25,8 @@ cores <- availableCores()-4
 ###
 
 nfolds <- 5 #CV folds
-nreps <- 20 #Number of times to repeat CV
-nmod <- 50 #Hyper parameter search limit
+nreps <- 10 #Number of times to repeat CV
+nmod <- 15 #Hyper parameter search limit
 #proportion_sample <- 0.2
 
 ##################################3 DON"T MODIFY ANYTHING BELOW THIS CODE ##########################
@@ -556,7 +556,7 @@ cat("\nTime take to run the model with",cores, "cores is", run.time, "seconds\n"
 
 time_df <- data.frame(
   cores = cores,
-  time = log.txt)
+  time = run.time)
 
 write_csv(time_df, str_c("ncores_",cores,".csv"))
 

--- a/01_predictclearing_mlr3.R
+++ b/01_predictclearing_mlr3.R
@@ -516,7 +516,8 @@ model_details <- data.frame(
   period = period,
   auc_mean = auc.median,
   auc_dist = I(list(auc$classif.auc)),
-  time = log.txt)
+  #time = log.txt)
+  time = -999)
 
 #saveRDS(model_details, str_c(results.path, model.name,"_modeltime.rds"))
 

--- a/01_predictclearing_mlr3.R
+++ b/01_predictclearing_mlr3.R
@@ -537,7 +537,8 @@ df.list <- crossing(studyarea$name,agent, period) %>%
             
 #Only NSW North Coast and all agents
 
-tic()
+tic.clearlog() # clear any times that have been logged
+tic()  # start the timer
 
 purrr::pwalk(list(
   region = df.list$region,
@@ -548,14 +549,14 @@ purrr::pwalk(list(
                 quiet =T))
 
 toc(log = TRUE, quiet = TRUE)
-log.txt <- unlist(tic.log(format = T))
+log.lst <- tic.log(format = FALSE) # store the row time timings
+run.time <- unlist(lapply(log.lst, function(x) x$toc - x$tic)) 
 
-print(str_c("Time take to run the model with ",cores, "cores ",log.txt))
+cat("\nTime take to run the model with",cores, "cores is", run.time, "seconds\n")
 
 time_df <- data.frame(
   cores = cores,
   time = log.txt)
-tic.clearlog()
 
 write_csv(time_df, str_c("ncores_",cores,".csv"))
 


### PR DESCRIPTION
The way the code was implemented, timings were being saved mixed with text characters. (eg: "32,1398.061 sec elapsed". Cleaned this up so just saves time in sections. 